### PR TITLE
docs: add EVAS-first parity guidance for PLL modeling

### DIFF
--- a/veriloga/SKILL.md
+++ b/veriloga/SKILL.md
@@ -37,6 +37,7 @@ real-world .va files plus a 171-module reference library (14,311 LOC).
 - **Category-specific patterns** → `references/categories/adc-sar.md`, `comparator.md`, etc.
 - **Project overrides** (naming, supply voltage, headers) → `references/customize.md`
 - **Domain classification help** → `references/domain-routing.md`
+- **EVAS-vs-Spectre parity gate for idt/idtmod decisions** → `references/evas-parity-gate.md`
 - **EVAS simulator support check** → `references/evas-capabilities.manifest`
 - **ADC behavioral verification** → `references/adc-testbench-guide.md` (runnable examples live under `../behavioral-va-eval/examples/`)
 - **Advanced syntax** (string parsing, current-domain functions, conditional compilation) → `references/verilog-a-advanced.md`
@@ -577,6 +578,30 @@ If fetched successfully, update the local cache.
 ```
 
 "Either" categories (DAC, PLL, Power/Switch) require code-level analysis.
+
+## idt/idtmod Policy (EVAS-first)
+
+For modules intended to be checked in both EVAS and Spectre:
+
+1. Generate EVAS-friendly model code first (event/discrete implementation)
+2. Run EVAS pre-check first; require functional dynamics before cross-simulator checks
+3. Run Spectre verification on the same stimulus and compare reports
+4. If mismatch exists, prioritize EVAS-side semantic fixes first
+5. EVAS fixes must not change EVAS matrix-solver core principles
+6. If repeated EVAS fixes are ineffective, then inspect model-code assumptions
+7. Enable `idt()` / `idtmod()` only when dual-simulator A/B evidence proves better consistency
+
+Mandatory flow:
+
+1. Build non-idt baseline model
+2. Run EVAS pre-check
+3. Run Spectre verification on identical testbench/stimulus
+4. If mismatch is above threshold, patch EVAS semantics and re-run
+5. After multiple ineffective EVAS patches, inspect model code
+6. Build idt/idtmod candidate only when justified
+7. Keep idt/idtmod only if mismatch metrics improve and lock behavior does not regress
+
+Use `references/evas-parity-gate.md` as the acceptance standard.
 
 ---
 

--- a/veriloga/references/categories/pll-clock.md
+++ b/veriloga/references/categories/pll-clock.md
@@ -15,6 +15,9 @@ Patterns for phase-locked loop building blocks: VCO, DCO, PFD, charge pump, freq
 
 ## VCO — Voltage-Controlled Oscillator
 
+For EVAS-first or EVAS+Spectre parity workflows, prefer a non-idt baseline first.
+Use `idtmod()` only after parity-gate A/B evidence (see `../evas-parity-gate.md`).
+
 The most common PLL block. Uses phase accumulation:
 
 ```
@@ -48,6 +51,50 @@ end
 - `$bound_step()` — forces max time-step so oscillation is sampled correctly
 - For square-wave output: `V(vout) <+ transition((phase < 0.5) ? vh : vl, ...)`
 - For noise: add `flicker_noise(Kf, exp, "vco_fn")` and `white_noise(Kw, "vco_wn")`
+
+## EVAS-friendly Alternative (No idtmod)
+
+Use timer-driven toggling with frequency updates in the event block:
+
+- For variable-period VCO/DCO/CPPLL clocks, prefer a single-argument absolute-time timer:
+  `@(timer(t_next))`
+- Do not use `@(timer(0.0, t_half))` with a time-varying `t_half` for oscillator scheduling.
+  In event-driven simulators this commonly schedules the next edge using the old period, so the
+  frequency update takes effect one edge late.
+
+```
+parameter real fo = 1.0e9;
+parameter real Kvco = 100.0e6;
+parameter real tedge = 10p;
+
+real vh, vl, vcm, inst_freq, t_next, t_half;
+integer state;
+
+analog begin
+    vh = V(VDD); vl = V(VSS); vcm = (vh + vl) / 2.0;
+
+    @(initial_step) begin
+        state = 0;
+        inst_freq = fo;
+        t_half = 0.5 / inst_freq;
+        t_next = $abstime + t_half;
+    end
+
+    @(timer(t_next)) begin
+        inst_freq = fo + Kvco * (V(vctr) - vcm);
+        if (inst_freq < 1.0) inst_freq = 1.0;
+        $bound_step(1.0 / (64.0 * inst_freq));
+        state = 1 - state;
+        t_half = 0.5 / inst_freq;
+        t_next = t_next + t_half;
+    end
+
+    V(vout) <+ vl + (vh - vl) * transition(state ? 1.0 : 0.0, 0, tedge, tedge);
+end
+```
+
+This pattern is usually easier to align between EVAS and Spectre than direct phase integration.
+It also avoids one-edge-late period application when the oscillation period changes over time.
 
 ## Frequency Divider
 
@@ -109,3 +156,5 @@ end
   for lock-in behavior
 - For DCO (digitally controlled oscillator): replace continuous `vctr` with a digital
   frequency word and discrete frequency steps
+- For variable-period oscillators, schedule the next edge with an explicit `t_next` state rather
+  than a two-argument periodic `timer(start, period)`

--- a/veriloga/references/domain-routing.md
+++ b/veriloga/references/domain-routing.md
@@ -22,6 +22,17 @@ Supported/unsupported constructs: read `evas-capabilities.manifest`.
 3. Edge detection uses `@(cross(...))` with explicit direction
 4. All state initialized in `@(initial_step)`
 
+### EVAS Parity Gate (before allowing idt/idtmod)
+
+For PLL/VCO-like modules that may request `idt()`/`idtmod()`:
+
+1. Build EVAS-friendly baseline first (no idt/idtmod)
+2. Build idt/idtmod candidate second
+3. Run both against Spectre on identical testbenches
+4. Keep idt/idtmod only if mismatch metrics improve materially and lock behavior does not regress
+
+Execution standard: `evas-parity-gate.md`.
+
 ### Invocation
 
 Check `customize.md` for `voltage_simulator_cmd`. If not configured, report
@@ -81,3 +92,6 @@ architectural exclusions** — EVAS will never add KCL solving.
 What may change:
 1. New `[supported]` constructs → update manifest
 2. CLI/runtime changes → update `voltage_simulator_cmd` and related examples in `customize.md`
+
+If local EVAS implementation status differs from the manifest for experimental operators,
+use parity-gate runtime evidence instead of parse success alone.

--- a/veriloga/references/evas-parity-gate.md
+++ b/veriloga/references/evas-parity-gate.md
@@ -1,0 +1,80 @@
+# EVAS-First Closed Loop (Against Spectre)
+
+Use this method for generated Verilog-A that must be consistent between EVAS and Virtuoso/Spectre.
+
+## Goal
+
+Keep the workflow deterministic and actionable:
+
+1. Treat EVAS as the primary expected behavior for fast iteration
+2. Use Virtuoso/Spectre as cross-check oracle on identical stimulus
+3. If mismatch appears, fix EVAS semantics first (without touching EVAS matrix-solver fundamentals)
+4. If repeated EVAS fixes do not improve mismatch, re-check model code assumptions
+
+## Ordered Workflow
+
+### Step 1: Generate EVAS-friendly model code
+
+For PLL/VCO/CPPLL style modules, start with:
+
+1. Edge events: `@(cross(...))`
+2. Discrete state updates in edge events or single-argument absolute-time timers such as
+   `@(timer(t_next))`
+3. Output shaping via `transition()`
+4. No `I() <+`, no `ddt()`, no `idt()`, no `idtmod()` (unless separately justified)
+
+For variable-period oscillator scheduling, avoid `@(timer(0.0, period))` when `period` is updated
+inside the event body. Prefer an explicit `t_next = t_next + t_half` pattern so the newly computed
+period controls the very next edge.
+
+### Step 2: EVAS pre-check
+
+Run EVAS first and require:
+
+1. Simulation success
+2. Non-degenerate waveform dynamics (not flatline, not NaN-only)
+3. Basic functional intent visible (for example: toggling clocks, lock progression, bounded control)
+
+### Step 3: Virtuoso/Spectre verification
+
+Run the same testbench and stimulus in Spectre and compare against EVAS report.
+
+Collect at least:
+
+1. Key waveform RMSE (state/control/output)
+2. Lock metrics (lock-time, lock flag occupancy)
+3. Final frequency/phase mismatch metrics in observation window
+
+### Step 4: Mismatch handling (EVAS-fix-first)
+
+If mismatch exceeds threshold:
+
+1. First modify EVAS frontend/runtime behavior only where semantics differ from Spectre expectations
+2. Do not modify EVAS matrix-solver core principles for this loop
+3. Re-run EVAS + Spectre on identical inputs after each EVAS fix
+
+If mismatch does not improve after multiple EVAS-side attempts, then inspect generated model code for conceptual errors.
+
+### Step 5: Optional idt/idtmod adoption
+
+Enable `idt()` / `idtmod()` only if all are true:
+
+1. EVAS run succeeds with meaningful dynamics (not flatline / not degenerate)
+2. Spectre run succeeds
+3. Relative improvement vs baseline is significant: at least 20% reduction on the primary mismatch metric
+4. No regression on lock behavior (lock-time delta and lock detect consistency remain acceptable)
+
+If any condition fails, keep the non-idtmod baseline.
+
+## Suggested Numeric Thresholds
+
+Tune per project, but start with:
+
+1. `primary_rmse_new <= 0.8 * primary_rmse_baseline`
+2. `lock_time_delta_new <= lock_time_delta_baseline + 5% * t_lock_target`
+3. Both simulators must report non-empty and non-constant key outputs
+
+## Important Caveat
+
+If EVAS implementation status for `idt/idtmod` is changing across versions, do not rely on parse success alone.
+Always verify runtime behavior (waveform is dynamic and physically plausible).

--- a/veriloga/references/verilog-a-advanced.md
+++ b/veriloga/references/verilog-a-advanced.md
@@ -102,6 +102,10 @@ I(IN, OUT) <+ V(sw) * transition(cond, 0, 10p);
 
 Sample or log at fixed time intervals.
 
+Use a single absolute-time state such as `next_sample` when the interval may change over time.
+Avoid `@(timer(start, period))` for variable-period scheduling, because the next trigger is often
+committed before the event body updates `period`.
+
 ```verilog
 real next_sample;
 


### PR DESCRIPTION
## Summary
This PR adds EVAS-first closed-loop guidance for PLL/VCO-style Verilog-A generation and review.

## What Changed
- add a new parity-gate reference: `veriloga/references/evas-parity-gate.md`
- update `veriloga/SKILL.md` to explicitly route idt/idtmod decisions through that parity gate
- update PLL category guidance to prefer a non-`idtmod()` baseline first for EVAS+Spectre workflows
- document the timer scheduling pattern `@(timer(t_next))` for variable-period oscillators
- update advanced Verilog-A notes to warn against two-argument `timer(start, period)` when the period changes dynamically
- update domain-routing guidance so parse support alone is not treated as sufficient for experimental operator adoption

## Why
Recent CPPLL/ADPLL closed-loop work showed that model authors need a clearer policy for when to stay with EVAS-friendly discrete/event-driven code and when `idt()`/`idtmod()` is justified.

The new guidance makes that decision evidence-based:

1. build an EVAS-friendly baseline first
2. verify EVAS behavior first
3. compare against Spectre on identical stimulus
4. only keep `idt/idtmod` if mismatch metrics materially improve without lock regression

## Validation Context
This guidance is grounded in the recent PLL closed-loop parity workflow used across EVAS and benchmark authoring, especially around:

- CPPLL timer-based lock behavior
- ADPLL timer-based and `idtmod`-compatible variants
- acceptance criteria based on waveform dynamics, mismatch reduction, and lock behavior stability

## Upstream Value
This should help future generated models avoid overusing `idt/idtmod` prematurely, while still leaving room for them when dual-simulator evidence shows they are the better choice.