### PR TITLE
docs: Spectre-safe PWL guidance, transition() style rules, and benchmark authoring notes

### DIFF
--- a/.github/workflows/pwl-lint.yml
+++ b/.github/workflows/pwl-lint.yml
@@ -1,0 +1,26 @@
+name: PWL Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pwl-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependency
+        run: python -m pip install pytest
+
+      - name: Run Spectre-safe PWL lint
+        run: python -m pytest -q tests/test_pwl_statements.py

--- a/evas-sim/SKILL.md
+++ b/evas-sim/SKILL.md
@@ -252,6 +252,12 @@ Rules:
 | Analog input (ADC) | `vsource type=sine sinedc=... ampl=... freq=...` | set `sinedc` to mid-rail |
 | Ramp / step | `vsource type=pwl` | explicit time-value pairs |
 
+Spectre-safe PWL rule:
+
+- Prefer a single-line form when practical: `wave=[ 0 0 10n 0.9 20n 0.2 ]`
+- If the PWL list must span multiple lines, use explicit Spectre continuations on the source line and every intermediate line until the closing `]`
+- Always keep time/value tokens paired; odd-length token lists are treated as malformed
+
 #### 5. `simulatorOptions`
 Minimal recommended set for behavioural Verilog-A:
 ```spectre

--- a/tests/test_pwl_statements.py
+++ b/tests/test_pwl_statements.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_DIR = ROOT / "evas-sim" / "examples"
+COMMENT_RE = re.compile(r"//.*$")
+
+
+def _strip_comment(line: str) -> str:
+    return COMMENT_RE.sub("", line)
+
+
+def _lint_pwl_file(path: Path) -> list[str]:
+    offenders: list[str] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    waiting_wave = False
+    in_wave = False
+    wave_tokens: list[str] = []
+    wave_start_lineno = 0
+    wave_start_line = ""
+
+    def start_wave(raw_line: str, lineno: int) -> None:
+        nonlocal in_wave, wave_start_lineno, wave_start_line, wave_tokens
+        in_wave = True
+        wave_start_lineno = lineno
+        wave_start_line = raw_line.strip()
+        wave_tokens = []
+
+    def add_wave_tokens(fragment: str) -> None:
+        cleaned = _strip_comment(fragment).replace("\\", " ").replace("[", " ").replace("]", " ")
+        wave_tokens.extend(token for token in cleaned.split() if token)
+
+    def finish_wave(path: Path) -> None:
+        if len(wave_tokens) % 2 != 0:
+            offenders.append(
+                f"{path.relative_to(ROOT)}:{wave_start_lineno}: odd number of PWL tokens in `{wave_start_line}`"
+            )
+
+    for lineno, raw_line in enumerate(lines, start=1):
+        line = _strip_comment(raw_line)
+        stripped = line.strip()
+        ends_with_continuation = raw_line.rstrip().endswith("\\")
+
+        if waiting_wave and "wave=[" in line:
+            waiting_wave = False
+            start_wave(raw_line, lineno)
+            if "]" not in line and not ends_with_continuation:
+                offenders.append(
+                    f"{path.relative_to(ROOT)}:{lineno}: multi-line PWL must use explicit continuation `\\`"
+                )
+            add_wave_tokens(line.split("wave=[", 1)[1])
+            if "]" in line:
+                in_wave = False
+                finish_wave(path)
+            continue
+
+        if "type=pwl" in line:
+            if "wave=[" in line:
+                start_wave(raw_line, lineno)
+                if "]" not in line and not ends_with_continuation:
+                    offenders.append(
+                        f"{path.relative_to(ROOT)}:{lineno}: multi-line PWL must use explicit continuation `\\`"
+                    )
+                add_wave_tokens(line.split("wave=[", 1)[1])
+                if "]" in line:
+                    in_wave = False
+                    finish_wave(path)
+                continue
+            waiting_wave = ends_with_continuation
+
+        if in_wave:
+            if "]" not in line and stripped and not ends_with_continuation:
+                offenders.append(
+                    f"{path.relative_to(ROOT)}:{lineno}: continued PWL lines must end with `\\` until `]` closes"
+                )
+            add_wave_tokens(line)
+            if "]" in line:
+                in_wave = False
+                finish_wave(path)
+
+    return offenders
+
+
+def test_evas_examples_use_spectre_safe_pwl_format() -> None:
+    offenders: list[str] = []
+
+    for tb_path in sorted(EXAMPLES_DIR.rglob("tb_*.scs")):
+        offenders.extend(_lint_pwl_file(tb_path))
+
+    assert not offenders, "Unsafe or malformed PWL sources remain:\n" + "\n".join(offenders)

--- a/veriloga/SKILL.md
+++ b/veriloga/SKILL.md
@@ -321,27 +321,30 @@ end
 
 Uninitialized variables default to 0 or garbage depending on simulator.
 
-**Rule 6 corollary — execution order:** EVAS compiles the analog block into two methods:
-`initial_step()` (fires first, at t=0) and `evaluate()` (fires second, then every timestep).
-Variables assigned in the bare `analog begin` block live in `evaluate()` and are still at their
-`__init__` default (0) when `initial_step()` runs. If `@(initial_step)` reads a variable that
-is computed in the bare block — e.g., via `$strobe` — it will print 0 even though the driven
-voltages are correct. Fix: compute the value inside `@(initial_step)` itself, or avoid reading
-bare-block variables from `@(initial_step)`.
+**Rule 6 corollary — startup style:** keep startup-dependent state explicit inside
+`@(initial_step)` even when simulators can see preceding analog assignments. Use it to seed PRBS,
+counters, lock streaks, and nonzero defaults. Avoid relying on ambiguous startup ordering when a
+single explicit initialization is clearer.
 
 ### Rule 7: Edge detection uses `@(cross())` with direction
 
 `+1` rising, `-1` falling. Omit direction only when both edges are needed.
 
-### Rule 8: Outputs use `transition()` — use `` `default_transition ``
+### Rule 8: Outputs use `transition()` — prefer a discrete target variable
 
 ```
 `default_transition 10p
-V(out_o) <+ transition(state ? vh : vl, 0);
+real out_target;
+out_target = state ? vh : vl;
+V(out_o) <+ transition(out_target, 0);
 ```
 
 **Pitfall:** Multiple `<+` to the same node *adds* contributions, not overwrites.
 Use a temporary variable and assign once.
+
+**Project style rule:** even if some simulators accept more compact expressions, benchmark gold and
+first-pass authored DUTs should prefer the explicit target-variable form above. It is easier to
+audit and keeps EVAS / Spectre authoring style aligned.
 
 ---
 
@@ -446,15 +449,23 @@ end
 ### Internal voltage nodes
 ```verilog
 voltage [15:0] shadow;
-V(shadow[i]) <+ transition(active ? 1 : 0, 0, 100p, 1p);
-V(OUT[i]) <+ transition((V(shadow[i]) > 0.5) ? vh : vl, 0);
+real shadow_target;
+real out_target;
+shadow_target = active ? 1.0 : 0.0;
+out_target = V(shadow[i]) > 0.5 ? vh : vl;
+V(shadow[i]) <+ transition(shadow_target, 0, 100p, 1p);
+V(OUT[i]) <+ transition(out_target, 0);
 ```
 
 ### `transition()` as intermediate variable
 ```verilog
+real clk_state;
 real clk_delayed;
-clk_delayed = transition(cond ? 1 : 0, 200p, 1p, 1p);
-V(CLKOUT) <+ transition((clk_delayed > 0.5) ? vh : vl, 0);
+real clkout_target;
+clk_state = cond ? 1.0 : 0.0;
+clk_delayed = transition(clk_state, 200p, 1p, 1p);
+clkout_target = clk_delayed > 0.5 ? vh : vl;
+V(CLKOUT) <+ transition(clkout_target, 0);
 ```
 
 ### `analog` single-line (no `begin/end`)
@@ -602,6 +613,44 @@ Mandatory flow:
 7. Keep idt/idtmod only if mismatch metrics improve and lock behavior does not regress
 
 Use `references/evas-parity-gate.md` as the acceptance standard.
+
+## Benchmark Authoring Notes
+
+These notes matter when the DUT you write will later become benchmark gold or will be evaluated in
+the `behavioral-veriloga-eval` pipeline.
+
+### Port discipline note
+
+Use one ANSI-inline `electrical` port per line. Do not rely on comma-sharing such as
+`inout electrical VDD, VSS`.
+
+### PRBS / LFSR note
+
+Initialize PRBS seeds to a nonzero state in `@(initial_step)`, for example:
+
+```verilog
+@(initial_step) begin
+    lfsr = 7'h01;
+end
+```
+
+### PLL parity note
+
+If a DUT will feed a PLL / clock benchmark, the benchmark metadata must use
+`"parity_policy": "pll_task_aware"`. The evaluation should compare lock / relock behavior,
+directional control pulses, and `vctrl` trends, not pointwise waveform error.
+
+### tb-generation handoff note
+
+When handing a DUT to a `tb-generation` task, the benchmark metadata should keep scoring to
+compile / execution gates only:
+
+```json
+{
+  "scoring": ["dut_compile", "tb_compile"],
+  "parity_policy": "not_required"
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- **evas-sim/SKILL.md**: Add Spectre-safe PWL rule — prefer single-line `wave=[...]` form; require explicit `\` continuations for multi-line PWL; tokens must be even-count (time/value pairs)
- **veriloga/SKILL.md**: Clarify Rule 6 startup style; update Rule 8 to prefer explicit `out_target` variable before `transition()` for audit clarity and EVAS/Spectre alignment; expand code examples; add **Benchmark Authoring Notes** section covering port discipline, PRBS init, PLL `parity_policy`, and tb-generation scoring gates
- **tests/test_pwl_statements.py**: PWL lint that walks all `evas-sim/examples/tb_*.scs` files and validates Spectre-safe format
- **.github/workflows/pwl-lint.yml**: CI job running the lint on push/PR to main

## Test plan

- [ ] `python3 -m pytest tests/test_pwl_statements.py` passes locally (1 passed)
- [ ] CI `pwl-lint` job passes on this PR
- [ ] No existing SKILL.md rules removed — additions only (except Rule 6/8 wording clarifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)