### PR TITLE
[codex] Add circuit mechanism guidance for EVAS parity

### DIFF
--- a/veriloga/SKILL.md
+++ b/veriloga/SKILL.md
@@ -343,6 +343,43 @@ V(out_o) <+ transition(state ? vh : vl, 0);
 **Pitfall:** Multiple `<+` to the same node *adds* contributions, not overwrites.
 Use a temporary variable and assign once.
 
+**Project style rule:** even if some simulators accept more compact expressions, benchmark gold and
+first-pass authored DUTs should prefer the explicit target-variable form above. It is easier to
+audit and keeps EVAS / Spectre authoring style aligned.
+
+**Multi-output corollary — target-buffer pattern:** for multiple transition-driven
+outputs, do not put `transition()` inside `if`/`case`/runtime `for` branches.
+Declare one target per output, or a `real target[0:N-1]` array. Update only those
+targets inside events and conditions. Put the electrical contributions at analog
+top level:
+
+```verilog
+real out_t[0:3];
+integer j;
+genvar k;
+
+analog begin
+    @(initial_step) begin
+        for (j = 0; j < 4; j = j + 1) out_t[j] = vlo;
+    end
+
+    @(cross(V(clk) - vth, +1)) begin
+        out_t[0] = state0 ? vhi : vlo;
+        out_t[1] = state1 ? vhi : vlo;
+        out_t[2] = state2 ? vhi : vlo;
+        out_t[3] = state3 ? vhi : vlo;
+    end
+
+    for (k = 0; k < 4; k = k + 1) begin
+        V(out[k]) <+ transition(out_t[k], 0, tr, tf);
+    end
+end
+```
+
+If a simulator or benchmark port style makes `genvar` inconvenient, explicitly
+unroll the contribution lines. The important rule is that the `transition()`
+contributions are unconditional and outside runtime `integer` loops.
+
 ---
 
 ## Category Index

--- a/veriloga/references/categories/adc-sar.md
+++ b/veriloga/references/categories/adc-sar.md
@@ -89,6 +89,48 @@ Pipeline stages use MDAC (multiplying DAC) with sub-ADC:
 - Pass residue to next stage
 - Each stage has its own clock phase
 
+## System-Level Decomposition
+
+Do not treat an ADC prompt as one opaque behavior. Split it into mechanism
+blocks, then connect those blocks with observable relations:
+
+| Block | Typical observable | Contract-style check |
+|---|---|---|
+| Sample / hold | `vin_sh`, `clks`, `phi1`, `phi2` | The sample/update clock has edges; sampled value follows input at the requested phase |
+| Quantizer / flash sub-ADC | `DOUT[*]`, `dout_*`, `dout_code` | Codes cover the expected range and are not stuck |
+| SAR control | `DP_DAC[*]`, `DM_DAC[*]`, `CMPCK`, `RDY`, `EOC` | Bit trial/control signals move; ready/end flag asserts after conversion |
+| CDAC / DAC reconstruction | `vout`, `VDAC_P`, `VDAC_N` | Output span is non-trivial and matches the same bit order/reference as the code |
+| Pipeline residue / MDAC | `vres`, `residue` | Residue changes across decision regions and stays bounded |
+| Calibration / trim | `TRIM_code`, `CAL*`, trim buses | Trim/control code converges or at least moves under the calibration stimulus |
+
+For an ADC-DAC round trip, the useful chain is:
+
+```
+sample clock -> sampled input -> quantizer code -> DAC reconstruction
+```
+
+The repair loop should therefore look at a vector of mechanism failures:
+missing clock edges, stuck code, wrong bit order, wrong reference scale,
+flat reconstruction output, missing ready flag, flat residue, or static
+calibration control. This is more useful than a single note such as "ADC
+failed", because it points to the broken internal relation.
+
+### Gold-Derived Robustness Lessons
+
+Gold sweeps should be non-mutating: copy the gold testbench/DUT to a result
+folder, perturb public stimulus parameters, and record the mechanism metrics.
+For `sar_adc_dac_weighted_8b_smoke`, sweeping input sine frequency showed:
+
+- `fin=50k..500k` passes the existing checker.
+- Code coverage drops from 224 unique codes at `100k` to 57 at `500k`.
+- Average reconstruction error rises from about `2.2mV` to `8.2mV`.
+- `fin=1M` became a timeout/error boundary in the local EVAS run, with only
+  partial metrics available.
+
+This tells the generator that input speed versus sampling cadence is part of
+the ADC contract. A repair that only toggles outputs is not enough; it must
+preserve sampling phase, bit order, reference scale, and reconstruction timing.
+
 ## Design Notes
 
 - SAR modules often have multiple clock domains (sample clock, comparator clock, main clock)

--- a/veriloga/references/categories/dac.md
+++ b/veriloga/references/categories/dac.md
@@ -3,6 +3,17 @@
 
 Patterns for digital-to-analog converters: binary-weighted, thermometer-coded, current-steering, R-string, and CDAC.
 
+## Spectre-Safe Bus Rules
+
+These are compile requirements for EVAS+Spectre parity, not style preferences:
+- MUST use fixed indices such as `V(DIN[0])`, `V(DIN[1])`, ... when reading a small bus inside an event.
+- MUST use `genvar` loops for bus output contributions so the simulator can statically unroll them.
+- MUST declare `genvar` at module scope before `analog begin`, never inside `analog begin`.
+- NEVER use `integer i; ... V(DIN[i])`, `V(CODE[i])`, `V(PTR[i])`, or `V(CELL_EN[i])`.
+- NEVER drive an electrical bus inside an `integer` loop: `for (i=0; ...) V(bus[i]) <+ ...` is not allowed.
+- MUST keep `transition()` contributions unconditional; compute target real values first, then drive the output once.
+- If unsure, explicitly write out each bit (`DIN[0]`, `DIN[1]`, `DIN[2]`, `DIN[3]`) instead of looping.
+
 ## Typical Ports
 
 | Port | Direction | Purpose |
@@ -30,13 +41,15 @@ parameter real    vcm     = 0.45;       // output common-mode
 ### Combinational (continuously evaluates inputs)
 
 ```
+genvar k;
+
 analog begin
     vh = V(VDD); vl = V(VSS);
     lsb = (vh - vl) / (1 << Nbit);
 
     accum = 0.0;
-    for (i = 0; i < Nbit; i = i + 1)
-        accum = accum + ((V(DIN[i]) > vth) ? (1 << i) : 0);
+    for (k = 0; k < Nbit; k = k + 1)
+        accum = accum + ((V(DIN[k]) > vth) ? (1 << k) : 0);
 
     V(VOUT) <+ transition(vl + accum * lsb, tdc, tt);
 end
@@ -45,6 +58,9 @@ end
 ### Latching (updates on clock/strobe edge)
 
 ```
+integer decimal;
+real held_value;
+
 analog begin
     vh = V(VDD); vl = V(VSS);
     vth_clk = (vh + vl) / 2.0;
@@ -54,8 +70,10 @@ analog begin
 
     @(cross(V(RDY) - vth_clk, +1)) begin
         decimal = 0;
-        for (i = 0; i < Nbit; i = i + 1)
-            decimal = decimal + ((V(DIN[i]) > vth) ? (1 << i) : 0);
+        if (V(DIN[0]) > vth) decimal = decimal + 1;
+        if (V(DIN[1]) > vth) decimal = decimal + 2;
+        if (V(DIN[2]) > vth) decimal = decimal + 4;
+        if (V(DIN[3]) > vth) decimal = decimal + 8;
         held_value = vl + decimal * (vh - vl) / ((1 << Nbit) - 1);
     end
 
@@ -75,11 +93,91 @@ end
 
 // Accumulate charge on each strobe
 state = 0.0;
-for (i = 0; i < Nbit; i = i + 1)
-    state = state + Cw[i] / Ctotal * ((V(DIN[i]) > vth) ? 1.0 : 0.0);
+state = state + Cw[0] / Ctotal * ((V(DIN[0]) > vth) ? 1.0 : 0.0);
+state = state + Cw[1] / Ctotal * ((V(DIN[1]) > vth) ? 1.0 : 0.0);
+state = state + Cw[2] / Ctotal * ((V(DIN[2]) > vth) ? 1.0 : 0.0);
+state = state + Cw[3] / Ctotal * ((V(DIN[3]) > vth) ? 1.0 : 0.0);
 
 V(VOUT) <+ transition(state * (vrefp - vrefn) + vrefn, tdc, tt);
 ```
+
+### DWA / Thermometer Pointer (Spectre-safe shape)
+
+For DWA, use integer arrays for internal state and `genvar` for bus contributions.
+Read small input buses with fixed indices inside clock events.
+
+This is an instance of the generic multi-output transition target-buffer pattern:
+state/event code updates held real targets, and electrical contributions are
+unconditional at analog top level. The same pattern applies to any multi-output
+digital/analog driver, not only DWA.
+
+```
+integer ptr_q, code_q, j;
+real cell_en_val[15:0], ptr_val[15:0];
+genvar k;
+
+analog begin
+    @(initial_step) begin
+        ptr_q = 0;
+        for (j = 0; j < 16; j = j + 1) begin
+            cell_en_val[j] = 0.0;
+            ptr_val[j] = (j == ptr_q) ? vhi : vlo;
+        end
+    end
+
+    @(cross(V(CLK) - vth, +1)) begin
+        code_q = 0;
+        if (V(CODE[0]) > vth) code_q = code_q + 1;
+        if (V(CODE[1]) > vth) code_q = code_q + 2;
+        if (V(CODE[2]) > vth) code_q = code_q + 4;
+        if (V(CODE[3]) > vth) code_q = code_q + 8;
+
+        ptr_q = (ptr_q + code_q) % 16;
+        for (j = 0; j < 16; j = j + 1) begin
+            cell_en_val[j] = 0.0;
+            ptr_val[j] = (j == ptr_q) ? vhi : vlo;
+        end
+    end
+
+    for (k = 0; k < 16; k = k + 1) begin
+        V(CELL_EN[k]) <+ transition(cell_en_val[k], 0, tt, tt);
+        V(PTR[k]) <+ transition(ptr_val[k], 0, tt, tt);
+    end
+end
+```
+
+### Thermometer-Code DAC Count-To-Voltage
+
+Thermometer DACs should map the population count of active input cells to the
+analog output.  Do not interpret thermometer inputs as a binary-weighted word.
+
+```
+integer count;
+real vout_target;
+
+analog begin
+    count = 0;
+    if (V(DIN0) > vth) count = count + 1;
+    if (V(DIN1) > vth) count = count + 1;
+    if (V(DIN2) > vth) count = count + 1;
+    if (V(DIN3) > vth) count = count + 1;
+    // Continue explicitly or use genvar/unrolled helpers for wider buses.
+
+    if (V(rst_n) < vth)
+        vout_target = 0.0;
+    else
+        vout_target = count * vstep;
+
+    V(VOUT) <+ transition(vout_target, 0, tt, tt);
+end
+```
+
+Key points:
+- Count asserted cells; do not use `DIN[k] * (1 << k)` for thermometer inputs.
+- Keep active-low reset released after startup if the checker observes settled
+  output levels.
+- If the prompt names scalar stimulus nodes such as `d0..d15`, keep those save
+  names visible even when the DUT uses an internal bus.
 
 ## Key Variables
 

--- a/veriloga/references/categories/digital-logic.md
+++ b/veriloga/references/categories/digital-logic.md
@@ -3,6 +3,17 @@
 
 Patterns for gates, flip-flops, latches, MUX, decoders, encoders, counters, shift registers, and state machines.
 
+## Spectre-Safe Event And Bus Rules
+
+These are compile requirements for EVAS+Spectre parity, not style preferences:
+- MUST put `@(cross(...))` event statements at the top level of the `analog begin` block.
+- MUST gate behavior inside the event body with `if (...)`.
+- NEVER write `if (...) @(cross(...))`, `else @(cross(...))`, or `case (...) @(cross(...))`.
+- MUST use fixed bit indices or `genvar` loops for electrical buses.
+- MUST declare `genvar` at module scope before `analog begin`, never inside `analog begin`.
+- NEVER use `integer i; ... V(bus[i])` in contributions or analog reads; that becomes a runtime vector index.
+- If a bus is wider than four bits, prefer `genvar k` for output contributions and fixed-index reads for control words.
+
 ## Typical Ports
 
 | Block | Ports |
@@ -80,7 +91,7 @@ end
 parameter integer Nbits = 8;
 
 integer count;
-genvar i;
+genvar k;
 
 analog begin
     vh = V(VDD); vl = V(VSS);
@@ -96,8 +107,8 @@ analog begin
         if (V(rst_i) < vth)
             count = (count + 1) % (1 << Nbits);
 
-    for (i = 0; i < Nbits; i = i + 1)
-        V(count_o[i]) <+ transition(((count >> i) & 1) ? vh : vl, tdel, trise, tfall);
+    for (k = 0; k < Nbits; k = k + 1)
+        V(count_o[k]) <+ transition(((count >> k) & 1) ? vh : vl, tdel, trise, tfall);
 end
 ```
 
@@ -107,24 +118,132 @@ end
 parameter integer Nbits = 4;
 
 integer sr[0:3];                       // one element per stage
-genvar i;
+integer j;
+genvar k;
 
 analog begin
     vh = V(VDD); vl = V(VSS);
     vth = (vh + vl) / 2.0;
 
     @(initial_step)
-        for (i = 0; i < Nbits; i = i + 1)
-            sr[i] = 0;
+        for (j = 0; j < Nbits; j = j + 1)
+            sr[j] = 0;
 
     @(cross(V(clk_i) - vth, +1)) begin
-        for (i = Nbits - 1; i > 0; i = i - 1)
-            sr[i] = sr[i-1];
+        for (j = Nbits - 1; j > 0; j = j - 1)
+            sr[j] = sr[j-1];
         sr[0] = (V(din_i) > vth) ? 1 : 0;
     end
 
-    for (i = 0; i < Nbits; i = i + 1)
-        V(dout_o[i]) <+ transition(sr[i] ? vh : vl, tdel, trise, tfall);
+    for (k = 0; k < Nbits; k = k + 1)
+        V(dout_o[k]) <+ transition(sr[k] ? vh : vl, tdel, trise, tfall);
+end
+```
+
+## Gray Counter
+
+A Gray counter should keep a normal binary counter internally, then encode the
+public outputs as `gray = binary ^ (binary >> 1)`.  Incrementing the Gray word
+directly often breaks the one-bit-transition property.
+
+```
+integer bin_count;
+integer gray_count;
+genvar k;
+
+analog begin
+    @(initial_step) begin
+        bin_count = 0;
+        gray_count = 0;
+    end
+
+    @(cross(V(rst_i) - vth, +1)) begin
+        bin_count = 0;
+        gray_count = 0;
+    end
+
+    @(cross(V(clk_i) - vth, +1)) begin
+        if (V(rst_i) > vth) begin
+            bin_count = 0;
+        end else begin
+            bin_count = (bin_count + 1) % (1 << Nbits);
+        end
+        gray_count = bin_count ^ (bin_count >> 1);
+    end
+
+    for (k = 0; k < Nbits; k = k + 1)
+        V(gray_o[k]) <+ transition(((gray_count >> k) & 1) ? vh : vl, tdel, trise, tfall);
+end
+```
+
+## Serializer With Frame Alignment
+
+For parallel-to-serial blocks, latch the parallel word on the load-qualified
+clock edge, then shift exactly one bit per clock.  If the prompt asks for a
+frame marker, assert it only for the first serialized bit of the loaded word.
+
+```
+integer word_q;
+integer bit_idx;
+integer sout_q;
+integer frame_q;
+
+analog begin
+    @(initial_step) begin
+        word_q = 0;
+        bit_idx = 0;
+        sout_q = 0;
+        frame_q = 0;
+    end
+
+    @(cross(V(clk_i) - vth, +1)) begin
+        if (V(load_i) > vth) begin
+            word_q = decoded_parallel_word;
+            bit_idx = Nbits - 1;       // MSB first
+            frame_q = 1;
+        end else begin
+            frame_q = 0;
+            if (bit_idx > 0)
+                bit_idx = bit_idx - 1;
+        end
+        sout_q = (word_q >> bit_idx) & 1;
+    end
+
+    V(sout_o)  <+ transition(sout_q ? vh : vl, tdel, trise, tfall);
+    V(frame_o) <+ transition(frame_q ? vh : vl, tdel, trise, tfall);
+end
+```
+
+## Parameterized Pulse Train
+
+When a task checks parameter overrides, declare the public parameter names
+exactly and let the instance line override them.  The output behavior should
+depend on those parameters, not on hard-coded constants.
+
+```
+parameter real    vhi  = 0.5;
+parameter integer reps = 2;
+
+integer emitted;
+integer out_state;
+real t_next;
+
+analog begin
+    @(initial_step) begin
+        emitted = 0;
+        out_state = 0;
+        t_next = 1n;
+    end
+
+    @(timer(t_next)) begin
+        if (emitted < 2 * reps) begin
+            out_state = 1 - out_state;
+            emitted = emitted + 1;
+            t_next = t_next + 2n;
+        end
+    end
+
+    V(out) <+ transition(out_state ? vhi : 0.0, 0, trise, tfall);
 end
 ```
 
@@ -199,5 +318,5 @@ Key points:
 - Use `case` statements for FSMs with >3 states — cleaner than nested if-else
 - Bit extraction: `(count >> i) & 1` extracts bit `i` from an integer
 - Shift registers shift *backwards* through the array (MSB first) to avoid overwriting
-- For async reset: place the reset `@(cross())` *before* the clock event — the simulator
-  processes events in order of appearance
+- For async reset: place the reset `@(cross())` as its own top-level event statement before
+  the clock event; put reset/enable checks inside event bodies.

--- a/veriloga/references/categories/pll-clock.md
+++ b/veriloga/references/categories/pll-clock.md
@@ -96,6 +96,108 @@ end
 This pattern is usually easier to align between EVAS and Spectre than direct phase integration.
 It also avoids one-edge-late period application when the oscillation period changes over time.
 
+## Closed-Loop PLL Repair Order
+
+When repairing a failing behavioral PLL, do not start by forcing the `lock`
+output.  Treat the loop as a staged mechanism and keep already-working stages
+intact.
+
+### Preserve The Verifier Interface
+
+Behavior repair must keep the public testbench interface stable.  If the
+Spectre harness passes parameters on the DUT instance, the Verilog-A module
+must declare those exact parameter names even when it also uses internal helper
+variables.
+
+Common PLL verifier parameters include:
+
+- `div_ratio`
+- `ratio_min`, `ratio_max`
+- `f_center`, `freq_step_hz`, `f_min`, `f_max`
+- `code_min`, `code_max`, `code_center`, `code_init`
+- `tedge`
+- `lock_tol`
+- `lock_count_target`
+
+It is fine to derive internal variables such as `ndiv`, `t_half`, `freq`, or
+`lock_threshold` from those public parameters, but do not replace the public
+parameter names with private-only names.  The repair may be behaviorally closer
+and still be rejected if the harness parameter interface is broken.
+
+### Stage 1: Feedback Edge Liveness
+
+If `ref_clk` has edges but `fb_clk` has none, the feedback generator is dead.
+Repair the oscillator/DCO and divider path first.
+
+- Use a held oscillator state plus an absolute `t_next` timer.
+- Initialize `t_next` in `@(initial_step)`.
+- In every `@(timer(t_next))` event, toggle the oscillator state and advance
+  `t_next` by a strictly positive half-period.
+- For CPPLL-style tasks, derive `fb_clk` from generated `dco_clk` edges through
+  a divider counter.
+- For ADPLL-style tasks without a separate `dco_clk`, the feedback output may
+  be the generated divided DCO clock.
+- Drive public clock pins from held states with unconditional `transition()`
+  contributions.
+
+### Stage 2: Feedback/Reference Ratio
+
+If feedback edges exist but the ratio is wrong, preserve edge liveness and
+repair cadence.
+
+- Keep one divider counter connected to oscillator/DCO edges.
+- Toggle or pulse `fb_clk` only from that counter.
+- Latch public ratio or hop controls on safe clock edges.
+- Be explicit about half-period versus full-period counting. If the DCO timer
+  fires on every half-cycle toggle and `fb_clk` toggles after `N` timer fires,
+  then one full `fb_clk` period is `2*N` timer intervals.
+- For ADPLL-style divided feedback, the common locked relation is
+  `f_dco ~= 2 * div_ratio * f_ref` when `fb_clk` toggles once per divider
+  count. If `div_ratio` changes without a matching nominal DCO frequency, the
+  late-window feedback/reference edge ratio will move high or low.
+- Choose `N` or the DCO period so late-window feedback and reference rising-edge
+  counts align. For a 50 MHz reference, `fb_clk` should have a near-20 ns
+  rising-edge period in the locked window.
+- Do not ignore public `f_center`, `freq_step_hz`, `f_min`, `f_max`, or
+  `div_ratio` and replace them with a fixed private oscillator.
+- Tune the nominal oscillator/DCO cadence and divider ratio so late-window
+  feedback and reference edge counts align.
+- Do not make `lock` pass while the ratio check is failing.
+
+### Stage 3: Control Movement
+
+If `vctrl_mon` or a control monitor is stuck, add a bounded loop-control state
+instead of a cosmetic waveform.
+
+- REF-leading error should move the control in the direction that speeds up the
+  feedback clock.
+- FB-leading error should move the control in the direction that slows down the
+  feedback clock.
+- A lightweight behavioral loop filter can accumulate bounded UP/DN corrections
+  into one real control variable.
+- Drive `vctrl_mon` from that same held control variable.
+- Use the same control variable to influence oscillator/DCO frequency so the
+  monitor movement is causally connected to feedback cadence.
+
+### Stage 4: Lock And Reacquire
+
+Assert `lock` only after earlier stages are plausible.
+
+- Maintain a stability counter over consecutive reference edges or comparison
+  windows with close reference/feedback cadence.
+- Use public `lock_tol` as a time or period tolerance and
+  `lock_count_target` as the required number of consecutive stable observations.
+- Treat `lock_count_target` as a lock-latency parameter, not a frequency-ratio
+  fix. Reducing it may assert lock earlier, but it does not repair a wrong
+  feedback cadence.
+- Do not use code-near-center as the only lock condition. The lock flag should
+  summarize observed ref/fb timing stability.
+- Assert `lock` after the stable count reaches the required window.
+- Clear or lower `lock` after reset, ratio hop, or a large frequency step.
+- For reacquire tasks, allow lock to drop during the disturbance and assert
+  again only after the post-step ratio restabilizes.
+- Never use a constant-high `lock` flag to hide a dead feedback path.
+
 ## Frequency Divider
 
 ```
@@ -123,6 +225,61 @@ analog begin
     end
 
     V(clk_out) <+ transition(out_state ? vh : vl, 0, tedge, tedge);
+end
+```
+
+## Bang-Bang Data/Clock Phase Detector
+
+An Alexander-style or bang-bang data-edge detector compares the timing of data
+edges against nearby clock edges.  The data input is not just a static logic
+value: recent edge time determines whether UP or DN should pulse.
+
+Repair order:
+
+- Capture data-edge and clock-edge times in held real variables.
+- If a data edge leads the clock edge inside the valid timing window, emit a
+  bounded UP pulse.
+- If a data edge lags the clock edge, emit a bounded DN pulse.
+- Clear pulses after a finite pulse width so UP and DN remain mostly
+  non-overlapping.
+- Retimed data should update on clock edges from the sampled data level.
+
+```
+real last_data_edge, last_clk_edge;
+real up_clear_t, dn_clear_t;
+integer up_q, dn_q, data_q, retimed_q;
+
+analog begin
+    @(initial_step) begin
+        last_data_edge = -1.0;
+        last_clk_edge = -1.0;
+        up_q = 0; dn_q = 0; retimed_q = 0;
+    end
+
+    @(cross(V(data) - vth, +1)) begin
+        last_data_edge = $abstime;
+        data_q = 1;
+        if (last_clk_edge >= 0.0 && ($abstime - last_clk_edge) < edge_window) begin
+            dn_q = 1;
+            dn_clear_t = $abstime + pulse_width;
+        end
+    end
+
+    @(cross(V(clk) - vth, +1)) begin
+        last_clk_edge = $abstime;
+        retimed_q = data_q;
+        if (last_data_edge >= 0.0 && ($abstime - last_data_edge) < edge_window) begin
+            up_q = 1;
+            up_clear_t = $abstime + pulse_width;
+        end
+    end
+
+    @(timer(up_clear_t)) up_q = 0;
+    @(timer(dn_clear_t)) dn_q = 0;
+
+    V(up) <+ transition(up_q ? vh : vl, 0, tedge, tedge);
+    V(dn) <+ transition(dn_q ? vh : vl, 0, tedge, tedge);
+    V(retimed_data) <+ transition(retimed_q ? vh : vl, 0, tedge, tedge);
 end
 ```
 

--- a/veriloga/references/evas-capabilities.manifest
+++ b/veriloga/references/evas-capabilities.manifest
@@ -1,15 +1,16 @@
-# EVAS Capability Manifest — LOCAL CACHE
+# EVAS Capability Manifest
 #
-# This is a cached copy. The source of truth is in the EVAS repo:
-# https://github.com/Arcadia-1/EVAS/blob/main/evas-capabilities.manifest
+# Source of truth for what the EVAS voltage-domain simulator supports.
+# External skills (e.g., veriloga-skills) fetch this file to determine
+# domain classification and simulation routing.
 #
-# Sync priority (SKILL.md § Domain Classification):
-# 1. evas --capabilities (if CLI installed)
-# 2. https://raw.githubusercontent.com/Arcadia-1/EVAS/main/evas-capabilities.manifest
-# 3. This file (fallback)
+# EVAS is an event-driven voltage-domain simulator. It does NOT solve KCL
+# equations — current contributions and continuous-time analog operators
+# are permanent architectural exclusions.
 #
-# If fetched successfully, overwrite this file with the latest version.
-# last_synced: 2026-03-15
+# Format: one construct per line. Lines starting with # are comments.
+# Update [supported] when EVAS adds new constructs.
+# The [unsupported] list should not change.
 
 [supported]
 # --- Contributions ---
@@ -19,9 +20,13 @@ V(node1, node2) <+
 @(cross())
 @(above())
 @(initial_step)
+@(timer())
+@(final_step)
 # combined: @(event1 or event2)
 # --- Operators ---
 transition()
+slew()
+last_crossing()
 `default_transition
 # --- Variables & Parameters ---
 parameter (real, integer, string)
@@ -43,6 +48,13 @@ $strobe
 $random
 $dist_uniform()
 $rdist_normal()
+$temperature
+$vt
+$fopen()
+$fclose()
+$fstrobe()
+$fwrite()
+$fdisplay()
 # --- Math ---
 abs() sqrt() ln() log() exp() pow()
 sin() cos() floor() ceil() min() max()
@@ -51,6 +63,10 @@ sin() cos() floor() ceil() min() max()
 `define
 # --- Other ---
 from [a:b] (parameter ranges)
+
+[not_yet_implemented]
+# Parser supports these constructs but the runner does not yet act on them.
+subckt / ends (Spectre netlist hierarchy flattening)
 
 [unsupported]
 # These are PERMANENT architectural exclusions — EVAS is event-driven,
@@ -63,15 +79,8 @@ laplace_nd()
 laplace_zp()
 flicker_noise()
 white_noise()
-$temperature
-$vt
 KCL-based solving
-@(timer())
-@(final_step)
-$fopen / $fclose / $fstrobe
-last_crossing()
 analysis()
 branch
 nature / discipline (custom)
-slew()
 limexp()


### PR DESCRIPTION
## Summary\n- add circuit-mechanism guidance for ADC/SAR, DAC, digital logic, and PLL/clock Verilog-A authoring\n- document EVAS/Spectre parity patterns, including transition target-buffer style and simulator-compatible behavioral constraints\n- update the EVAS capability manifest to reflect supported event-driven Verilog-A constructs\n\n## Validation\n- git diff --check\n- checked for unresolved merge-conflict markers\n\n## Notes\n- This branch is based on the current upstream/main to keep the PR focused on this change set.