### PR TITLE
[codex] Add EVAS parity follow-up guidance

### DIFF
--- a/.github/workflows/pwl-lint.yml
+++ b/.github/workflows/pwl-lint.yml
@@ -1,4 +1,4 @@
-name: PWL Lint
+name: Static Lints
 
 on:
   push:
@@ -22,5 +22,5 @@ jobs:
       - name: Install test dependency
         run: python -m pip install pytest
 
-      - name: Run Spectre-safe PWL lint
-        run: python -m pytest -q tests/test_pwl_statements.py
+      - name: Run static lint tests
+        run: python -m pytest -q tests

--- a/tests/test_spectre_portability.py
+++ b/tests/test_spectre_portability.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from veriloga.references.check_spectre_portability import ROOT, check_paths, scan_text
+
+
+def test_flags_rigid_voltage_branch_triangle() -> None:
+    text = """
+module vco_bad(OUTP, OUTN, VSS);
+analog begin
+    V(OUTP, VSS) <+ vcm + vdiff;
+    V(OUTN, VSS) <+ vcm - vdiff;
+    V(OUTP, OUTN) <+ 2.0 * vdiff + noise_v;
+end
+endmodule
+"""
+
+    findings = scan_text(Path("vco_bad.va"), text)
+
+    assert len(findings) == 1
+    assert "OUTN, OUTP, VSS" in findings[0].message
+    assert "rigid ideal voltage-branch triangle" in findings[0].message
+
+
+def test_allows_two_voltage_branches_plus_current_injection() -> None:
+    text = """
+module vco_good(OUTP, OUTN, VSS);
+analog begin
+    V(OUTP, VSS) <+ outp_target;
+    V(OUTN, VSS) <+ outn_target;
+    I(OUTP, OUTN) <+ noise_i;
+end
+endmodule
+"""
+
+    assert scan_text(Path("vco_good.va"), text) == []
+
+
+def test_ignores_commented_voltage_branches() -> None:
+    text = """
+module comments_only(A, B, C);
+analog begin
+    V(A, B) <+ vab;
+    // V(A, C) <+ vac;
+    /*
+    V(B, C) <+ vbc;
+    */
+end
+endmodule
+"""
+
+    assert scan_text(Path("comments_only.va"), text) == []
+
+
+def test_flags_runtime_indexed_analog_bus_reads() -> None:
+    text = """
+module bad_bus(DIN, OUT);
+integer i;
+analog begin
+    for (i = 0; i < 4; i = i + 1)
+        if (V(DIN[i]) > vth) code = code + (1 << i);
+end
+endmodule
+"""
+
+    findings = scan_text(Path("bad_bus.va"), text)
+
+    assert len(findings) == 1
+    assert "runtime-indexed analog bus read V(DIN[i])" in findings[0].message
+
+
+def test_allows_fixed_and_genvar_bus_indices() -> None:
+    text = """
+module good_bus(DIN, OUT);
+genvar k;
+genvar step;
+analog begin
+    if (V(DIN[0]) > vth) code = code + 1;
+    if (V(DIN[`NUM_ADC_BITS-step+1]) > vth) code = code + 1;
+    for (k = 0; k < 4; k = k + 1)
+        V(OUT[k]) <+ transition(out_t[k], 0, tt, tt);
+end
+endmodule
+"""
+
+    assert scan_text(Path("good_bus.va"), text) == []
+
+
+def test_repository_examples_are_free_of_rigid_branch_triangles() -> None:
+    findings = check_paths([ROOT / "veriloga" / "assets"])
+
+    assert not findings, "Spectre portability findings remain:\n" + "\n".join(
+        finding.format() for finding in findings
+    )

--- a/veriloga/SKILL.md
+++ b/veriloga/SKILL.md
@@ -652,6 +652,28 @@ compile / execution gates only:
 }
 ```
 
+### Requirement-to-code checklist
+
+For benchmark or eval-style DUT generation, the final assistant response must
+include an explicit coverage checklist that maps each prompt requirement to the
+generated code location. Use file/line references when available, or a precise
+identifier when line numbers are not available yet.
+
+The checklist must cover at least:
+
+- Required ports and bus widths
+- Required public parameters
+- Reset, lock, ready, or end-of-conversion behavior
+- Noise, jitter, mismatch, or monitor behavior named in the prompt
+- `$bound_step()` or equivalent timestep control for oscillator/source tasks
+- `idt()` / `idtmod()` acceptance or rejection under `references/evas-parity-gate.md`
+
+Do not summarize this as "all requirements implemented." If a prompt item is
+intentionally not implemented, mark it as not applicable or deferred and give
+the simulator/parity reason. Before finalizing a benchmark answer, re-read the
+prompt/eval metadata and confirm the signature items above are visible in the
+code or explicitly rejected by the domain-routing rules.
+
 ---
 
 ## Simulation Routing

--- a/veriloga/references/categories/pll-clock.md
+++ b/veriloga/references/categories/pll-clock.md
@@ -96,6 +96,75 @@ end
 This pattern is usually easier to align between EVAS and Spectre than direct phase integration.
 It also avoids one-edge-late period application when the oscillation period changes over time.
 
+## Differential VCO Output Topology
+
+Do not over-constrain a differential VCO output with three independent ideal
+voltage branches. Spectre treats these as ideal branch equations, so this shape
+can create a rigid-branch topology fatal even when EVAS accepts it:
+
+```verilog
+// Unsafe: OUTP, OUTN, and VSS are tied by three ideal voltage constraints.
+V(OUTP, VSS) <+ vcm + vdiff;
+V(OUTN, VSS) <+ vcm - vdiff;
+V(OUTP, OUTN) <+ 2.0 * vdiff + noise_v;
+```
+
+General rule: if two pin pairs already share a reference, such as
+`OUTP-VSS` and `OUTN-VSS`, do not add a third ideal `V(OUTP, OUTN) <+`
+constraint across the same two output pins. Add differential perturbations to
+the existing output targets before the single-ended contributions, or use a
+current-domain perturbation path.
+
+Preferred shapes:
+
+```verilog
+// Voltage-domain target style: add perturbation before the two output drives.
+outp_target = vcm + vdiff + 0.5 * noise_v;
+outn_target = vcm - vdiff - 0.5 * noise_v;
+V(OUTP, VSS) <+ transition(outp_target, 0, tedge, tedge);
+V(OUTN, VSS) <+ transition(outn_target, 0, tedge, tedge);
+```
+
+```verilog
+// Current-domain style: inject differential noise without an ideal voltage loop.
+I(OUTP, OUTN) <+ noise_i;
+```
+
+For finite-output-impedance models, use a Norton-style path with conductance
+and current injection rather than a third ideal differential voltage source.
+EVAS does not solve the same KCL/KVL topology as Spectre, so EVAS-only passing
+does not prove that an ideal voltage-branch topology is Spectre-portable.
+
+## Monitor Node Unit Discipline
+
+Monitor pins are voltages. Do not drive a monitor node with an unscaled physical
+quantity whose numeric value is far outside a reasonable voltage range. A common
+failure is:
+
+```verilog
+// Unsafe at GHz operation: this drives about 1e9 V onto freq_mon.
+V(freq_mon) <+ freq;
+```
+
+Use an explicit scale parameter so the monitor voltage has documented units:
+
+```verilog
+parameter real freq_mon_scale = 1e-9;  // GHz on freq_mon
+V(freq_mon) <+ freq * freq_mon_scale;
+```
+
+Apply the same discipline to other PLL monitors:
+
+- Frequency monitors: scale Hz to GHz/MHz/kHz on the voltage node.
+- Phase monitors: document rad-to-V scaling, for example `phase_mon_scale`.
+- Control-voltage monitors: no scale is needed when the state is already volts.
+- Divider-ratio or code monitors: dimensionless values may be driven directly
+  only when their range is small; otherwise add a scale parameter.
+
+Passing in EVAS is not enough for monitor nodes because EVAS may not expose DC
+or initial-condition blowup the way Spectre does. If a monitor can reach
+hundreds of volts or more, scale it before using it as a voltage contribution.
+
 ## Frequency Divider
 
 ```

--- a/veriloga/references/check_spectre_portability.py
+++ b/veriloga/references/check_spectre_portability.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from itertools import combinations
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+LINE_COMMENT_RE = re.compile(r"//.*$")
+VOLTAGE_BRANCH_RE = re.compile(r"\bV\s*\(\s*([^,\)\n]+)\s*,\s*([^)]+?)\s*\)\s*<\+")
+ANALOG_BUS_READ_RE = re.compile(
+    r"\bV\s*\(\s*([A-Za-z_]\w*)\s*\[\s*([^\]\n]+?)\s*\](?:\s*,|\s*\))"
+)
+GENVAR_DECL_RE = re.compile(r"\bgenvar\s+([^;]+);")
+IDENT_RE = re.compile(r"[A-Za-z_]\w*")
+MACRO_RE = re.compile(r"`[A-Za-z_]\w*")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    lineno: int
+    message: str
+
+    def format(self) -> str:
+        try:
+            display_path = self.path.relative_to(ROOT)
+        except ValueError:
+            display_path = self.path
+        return f"{display_path}:{self.lineno}: {self.message}"
+
+
+def _strip_block_comments_preserve_lines(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        return "\n" * match.group(0).count("\n")
+
+    return BLOCK_COMMENT_RE.sub(replace, text)
+
+
+def _normalize_node(node: str) -> str:
+    return re.sub(r"\s+", "", node)
+
+
+def _collect_genvars(text: str) -> set[str]:
+    genvars: set[str] = set()
+    for match in GENVAR_DECL_RE.finditer(text):
+        genvars.update(IDENT_RE.findall(match.group(1)))
+    return genvars
+
+
+def _is_static_bus_index(index: str, genvars: set[str]) -> bool:
+    index = index.strip()
+    if re.fullmatch(r"\d+", index):
+        return True
+    if index in genvars:
+        return True
+    expr = MACRO_RE.sub("0", index)
+    identifiers = IDENT_RE.findall(expr)
+    return bool(identifiers) and all(identifier in genvars for identifier in identifiers)
+
+
+def scan_text(path: Path, text: str) -> list[Finding]:
+    """Find Spectre-portability hazards that EVAS-style checks can miss."""
+    cleaned = _strip_block_comments_preserve_lines(text)
+    genvars = _collect_genvars(cleaned)
+    pair_lines: dict[tuple[str, str], list[int]] = {}
+    nodes: set[str] = set()
+    findings: list[Finding] = []
+
+    for lineno, raw_line in enumerate(cleaned.splitlines(), start=1):
+        line = LINE_COMMENT_RE.sub("", raw_line)
+        for match in VOLTAGE_BRANCH_RE.finditer(line):
+            a = _normalize_node(match.group(1))
+            b = _normalize_node(match.group(2))
+            if not a or not b or a == b:
+                continue
+            pair = tuple(sorted((a, b)))
+            pair_lines.setdefault(pair, []).append(lineno)
+            nodes.update(pair)
+
+        for match in ANALOG_BUS_READ_RE.finditer(line):
+            bus = match.group(1)
+            index = match.group(2).strip()
+            if not _is_static_bus_index(index, genvars):
+                findings.append(
+                    Finding(
+                        path=path,
+                        lineno=lineno,
+                        message=(
+                            f"runtime-indexed analog bus read V({bus}[{index}]); "
+                            "Spectre requires fixed indices or genvar-unrolled access"
+                        ),
+                    )
+                )
+
+    for trio in combinations(sorted(nodes), 3):
+        pairs = [
+            tuple(sorted((trio[0], trio[1]))),
+            tuple(sorted((trio[0], trio[2]))),
+            tuple(sorted((trio[1], trio[2]))),
+        ]
+        if all(pair in pair_lines for pair in pairs):
+            first_line = min(pair_lines[pair][0] for pair in pairs)
+            findings.append(
+                Finding(
+                    path=path,
+                    lineno=first_line,
+                    message=(
+                        "rigid ideal voltage-branch triangle among "
+                        f"{trio[0]}, {trio[1]}, {trio[2]}; avoid independent "
+                        "V(a,b) <+ constraints on all three node pairs"
+                    ),
+                )
+            )
+
+    return findings
+
+
+def iter_veriloga_files(paths: Iterable[Path]) -> Iterable[Path]:
+    for path in paths:
+        if path.is_dir():
+            yield from sorted(path.rglob("*.va"))
+        elif path.suffix == ".va":
+            yield path
+
+
+def check_paths(paths: Iterable[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in iter_veriloga_files(paths):
+        findings.extend(scan_text(path, path.read_text(encoding="utf-8")))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check Verilog-A Spectre portability hazards.")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[ROOT / "veriloga"],
+        help="Verilog-A files or directories to scan",
+    )
+    args = parser.parse_args()
+
+    findings = check_paths(args.paths)
+    for finding in findings:
+        print(finding.format())
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add benchmark/eval final-response checklist guidance so generated Verilog-A answers map explicit requirements back to code locations.
- Document Spectre-safe differential VCO output topology guidance to avoid rigid ideal-voltage branch triangles that EVAS-only checks can miss.
- Document monitor-node unit discipline, including `freq_mon_scale = 1e-9` for GHz frequency monitors.
- Add a Spectre portability checker and tests for rigid voltage-branch triangles and runtime-indexed analog bus reads.

## Issue Coverage
- Addresses #8 on the skill side with the requirement-to-code checklist. The companion executable guardrail is in `Arcadia-1/behavioral-veriloga-eval` PR #6.
- Closes #9 with VCO topology guidance plus a portability checker rule.
- Closes #10 with monitor-node unit scaling guidance.

## Validation
- `python3 -m pytest -q tests`
- `python3 veriloga/references/check_spectre_portability.py veriloga`
- `git diff --check HEAD`
